### PR TITLE
Add new lint rule for relative imports

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -24,6 +24,8 @@ linter:
   rules:
     # avoid_print: false  # Uncomment to disable the `avoid_print` rule
     directives_ordering: true
+    # avoid root imports https://dart.dev/tools/linter-rules/prefer_relative_imports
+    prefer_relative_imports: true
 
 analyzer:
   errors:

--- a/lib/common/util.dart
+++ b/lib/common/util.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 import 'package:archive/archive.dart';
 import 'package:file_picker/file_picker.dart';
-import 'package:zebra/model/goal.dart';
+import '../model/goal.dart';
 
 /// Function that parses Finch zip export file and updates the goals model.
 Future<Map<String, List<Goal>>> getAndParseFinchExport(FilePickerResult? result) async {

--- a/lib/widgets/home.dart
+++ b/lib/widgets/home.dart
@@ -1,13 +1,13 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:zebra/widgets/selector/native_goal_selector.dart';
 
 import '../model/goals.dart';
 import 'card.dart' as card_widget;
 import 'insights/heatmap.dart';
 import 'insights/heatmap_calendar.dart';
 import 'selector/goal_selector.dart';
+import 'selector/native_goal_selector.dart';
 import 'upload_button.dart';
 
 class ZebraHomePage extends StatelessWidget {

--- a/lib/widgets/selector/goal_selector.dart
+++ b/lib/widgets/selector/goal_selector.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:provider/provider.dart';
-import 'package:zebra/model/goals.dart';
 
 import '../../common/constants.dart';
+import '../../model/goals.dart';
 
 /// Widget to display a selector for a list of goals.
 class GoalSelector extends StatefulWidget {

--- a/lib/widgets/selector/native_goal_selector.dart
+++ b/lib/widgets/selector/native_goal_selector.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_native_select/flutter_native_select.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:provider/provider.dart';
-import 'package:zebra/model/goals.dart';
 
 import '../../common/constants.dart';
+import '../../model/goals.dart';
 
 /// Widget to display a native selector for a list of goals.
 class NativeGoalSelector extends StatelessWidget {


### PR DESCRIPTION
### Overview

Adding a new lint rule to the project. Dart doesn't have a strong preference for this but it is important to be consistent. `prefer_relative_imports` already exists so we will use that.

https://dart.dev/tools/linter-rules/prefer_relative_imports

### Changes in this PR

- Add new lint rule.
- Run autofix in the codebase.