### PR TITLE
Add support for journeys

### DIFF
--- a/lib/common/util.dart
+++ b/lib/common/util.dart
@@ -3,39 +3,70 @@ import 'dart:convert';
 import 'package:archive/archive.dart';
 import 'package:file_picker/file_picker.dart';
 import '../model/goal.dart';
+import '../model/journey.dart';
+
+/// Function that parses Finch zip export file and updates the journeys model.
+Future<List<Journey>> getAndParseFinchExportForJourneys(FilePickerResult? result) async {
+  final archive = await parseFinchExport(result);
+
+  for (final file in archive) {
+    // Goals are stored in Bullet.json
+    if (file.isFile && file.name == "Bullet.json") {
+      final goalBytes = file.content as List<int>;
+      final journeyRaw = (jsonDecode(utf8.decode(goalBytes)) as Map<String, dynamic>)['data'];
+      
+      final journeys = List<Journey>.empty();
+      for (var journey in journeyRaw) {
+        final g = Journey.fromJson(journey);
+        // Only save repeating goals
+        if (g.bulletType == 3) {
+          journeys.add(journey);
+        }
+      }
+      return journeys;
+    }
+  }
+  return List.empty();
+}
 
 /// Function that parses Finch zip export file and updates the goals model.
 Future<Map<String, List<Goal>>> getAndParseFinchExport(FilePickerResult? result) async {
+  final archive = await parseFinchExport(result);
+  
+  for (final file in archive) {
+    // Goals are stored in Bullet.json
+    if (file.isFile && file.name == "Bullet.json") {
+      final goalBytes = file.content as List<int>;
+      final goalsRaw = (jsonDecode(utf8.decode(goalBytes)) as Map<String, dynamic>)['data'];
+      final goals = <String, List<Goal>>{};
+      for (var goal in goalsRaw) {
+        final g = Goal.fromJson(goal);
+        // Only save repeating goals
+        if (g.cadence?.periodFrequency != null) {
+          if (goals[g.name] == null) {
+            goals[g.name] = [];
+          }
+          goals[g.name]?.add(g);
+        }
+      }
+      return goals;
+    }
+  }
+  return {};
+}
+
+/// Function that parses Finch zip export file and updates the goals model.
+Future<Archive> parseFinchExport(FilePickerResult? result) async {
   if (result == null || !result.files.isNotEmpty) {
-    return {};
+    throw "Failed to read file from zip file";
   }
   final bytes = result.files.first.bytes?.toList();
   if (bytes == null) {
-    return {};
+    throw "Failed to read bytes from zip file";
   }
   try {
     final archive = ZipDecoder().decodeBytes(bytes);
-    
-    for (final file in archive) {
-      // Goals are stored in Bullet.json
-      if (file.isFile && file.name == "Bullet.json") {
-        final goalBytes = file.content as List<int>;
-        final goalsRaw = (jsonDecode(utf8.decode(goalBytes)) as Map<String, dynamic>)['data'];
-        final goals = <String, List<Goal>>{};
-        for (var goal in goalsRaw) {
-          final g = Goal.fromJson(goal);
-          // Only save repeating goals
-          if (g.cadence?.periodFrequency != null) {
-            if (goals[g.name] == null) {
-              goals[g.name] = [];
-            }
-            goals[g.name]?.add(g);
-          }
-        }
-        return goals;
-      }
-    }
-    return {};
+    return archive;
   } catch (e) {
     // ignore: avoid_print
     print("Failed to extract zip file$e");

--- a/lib/common/util.dart
+++ b/lib/common/util.dart
@@ -17,10 +17,15 @@ Future<List<Journey>> getAndParseFinchExportForJourneys(FilePickerResult? result
       
       final journeys = List<Journey>.empty();
       for (var journey in journeyRaw) {
-        final g = Journey.fromJson(journey);
-        // Only save repeating goals
-        if (g.bulletType == 3) {
-          journeys.add(journey);
+        try {
+          final g = Journey.fromJson(journey);
+          // Only save repeating goals
+          if (g.bulletType == 3) {
+            journeys.add(journey);
+          }
+        } catch (e) {
+          // todo find out why this exception is throw, journey variable should be parseable by Journey 
+          print(e);
         }
       }
       return journeys;

--- a/lib/common/util.dart
+++ b/lib/common/util.dart
@@ -58,7 +58,7 @@ Future<Map<String, List<Goal>>> getAndParseFinchExport(FilePickerResult? result)
 /// Function that parses Finch zip export file and updates the goals model.
 Future<Archive> parseFinchExport(FilePickerResult? result) async {
   if (result == null || !result.files.isNotEmpty) {
-    throw "Failed to read file from zip file";
+    throw "Failed to read file, zip is empty.";
   }
   final bytes = result.files.first.bytes?.toList();
   if (bytes == null) {

--- a/lib/common/util.dart
+++ b/lib/common/util.dart
@@ -15,17 +15,12 @@ Future<List<Journey>> getAndParseFinchExportForJourneys(FilePickerResult? result
       final goalBytes = file.content as List<int>;
       final journeyRaw = (jsonDecode(utf8.decode(goalBytes)) as Map<String, dynamic>)['data'];
       
-      final journeys = List<Journey>.empty();
+      final journeys = <Journey>[];
       for (var journey in journeyRaw) {
-        try {
-          final g = Journey.fromJson(journey);
-          // Only save repeating goals
-          if (g.bulletType == 3) {
-            journeys.add(journey);
-          }
-        } catch (e) {
-          // todo find out why this exception is throw, journey variable should be parseable by Journey 
-          print(e);
+        final g = Journey.fromJson(journey);
+        // Journeys have type 3
+        if (g.bulletType == 3) {
+          journeys.add(g);
         }
       }
       return journeys;

--- a/lib/model/journey.dart
+++ b/lib/model/journey.dart
@@ -1,6 +1,6 @@
 import 'package:json_annotation/json_annotation.dart';
 
-/// This allows the `Goal` class to access private members in
+/// This allows the `Journey` class to access private members in
 /// the generated file. The value for this is *.g.dart, where
 /// the star denotes the source file name.
 part 'journey.g.dart';
@@ -17,13 +17,13 @@ class Journey {
   @JsonKey(required: true, name: 'bullet_type')
   int bulletType;
 
-  /// A necessary factory constructor for creating a new Goal instance
-  /// from a map. Pass the map to the generated `_$GoalFromJson()` constructor.
-  /// The constructor is named after the source class, in this case, Goal.
+  /// A necessary factory constructor for creating a new Journey instance
+  /// from a map. Pass the map to the generated `_$JourneyFromJson()` constructor.
+  /// The constructor is named after the source class, in this case, Journey.
   factory Journey.fromJson(Map<String, dynamic> json) => _$JourneyFromJson(json);
 
   /// `toJson` is the convention for a class to declare support for serialization
   /// to JSON. The implementation simply calls the private, generated
   /// helper method `_$JourneyFromJson`.
-  Map<String, dynamic> toJson() => _$JourneyFromJson(this);
+  Map<String, dynamic> toJson() => _$JourneyToJson(this);
 }

--- a/lib/model/journey.dart
+++ b/lib/model/journey.dart
@@ -1,0 +1,29 @@
+import 'package:json_annotation/json_annotation.dart';
+
+/// This allows the `Goal` class to access private members in
+/// the generated file. The value for this is *.g.dart, where
+/// the star denotes the source file name.
+part 'journey.g.dart';
+
+/// An annotation for the code generator to know that this class needs the
+/// JSON serialization logic to be generated.
+@JsonSerializable(explicitToJson: true)
+class Journey {
+  Journey(this.name, this.bulletType);
+
+  @JsonKey(required: true, name: 'text')
+  String name;
+
+  @JsonKey(required: true, name: 'bullet_type')
+  int bulletType;
+
+  /// A necessary factory constructor for creating a new Goal instance
+  /// from a map. Pass the map to the generated `_$GoalFromJson()` constructor.
+  /// The constructor is named after the source class, in this case, Goal.
+  factory Journey.fromJson(Map<String, dynamic> json) => _$JourneyFromJson(json);
+
+  /// `toJson` is the convention for a class to declare support for serialization
+  /// to JSON. The implementation simply calls the private, generated
+  /// helper method `_$JourneyFromJson`.
+  Map<String, dynamic> toJson() => _$JourneyFromJson(this);
+}

--- a/lib/model/journey.g.dart
+++ b/lib/model/journey.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'journey.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Journey _$JourneyFromJson(Map<String, dynamic> json) {
+  $checkKeys(
+    json,
+    requiredKeys: const ['text', 'bullet_type'],
+  );
+  return Journey(
+    json['text'] as String,
+    (json['bullet_type'] as num).toInt(),
+  );
+}
+
+Map<String, dynamic> _$JourneyToJson(Journey instance) => <String, dynamic>{
+      'text': instance.name,
+      'bullet_type': instance.bulletType,
+    };

--- a/lib/widgets/upload_button.dart
+++ b/lib/widgets/upload_button.dart
@@ -18,6 +18,7 @@ class UploadButton extends StatelessWidget {
     try {
       FilePickerResult? result = await FilePicker.platform.pickFiles(type: FileType.custom, allowedExtensions: ["zip"], withData: true );
       final goals = await getAndParseFinchExport(result);
+      final journeys = await getAndParseFinchExportForJourneys(result);
       final reports = <String, List<Report>>{};
       for (var key in goals.keys) {
         final goal = goals[key];
@@ -34,7 +35,7 @@ class UploadButton extends StatelessWidget {
       await box.clear();
       await box.putAll(reports);
       Fluttertoast.showToast(
-        msg: "Imported",
+        msg: "Imported ${journeys.length} journeys",
         toastLength: Toast.LENGTH_SHORT,
         gravity: ToastGravity.CENTER,
         fontSize: 16.0,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -472,6 +472,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  mocktail:
+    dependency: "direct dev"
+    description:
+      name: mocktail
+      sha256: "890df3f9688106f25755f26b1c60589a92b3ab91a22b8b224947ad041bf172d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   nested:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dev_dependencies:
   json_serializable: ^6.8.0
   hive_generator: ^2.0.1
   hive_test: ^1.0.1
+  mocktail: ^1.0.4
 
 flutter:
   uses-material-design: true

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -1,16 +1,22 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:zebra/common/util.dart';
 
 
+class MockImport extends Mock implements FilePickerResult {}
+
 void main() {
-  test('Util functions', () async {
-    expect(await getAndParseFinchExport(null), {});
+  final mockImport = MockImport();
+
+  group('Util functions', () {
+    test('Parse null import correctly', () async {
+      expect(() async => await getAndParseFinchExportForJourneys(null), throwsA("Failed to read file, zip is empty."));
+    });
+
+    test('Parse empty import correctly', () async {
+      when(() => mockImport.files).thenReturn([]);
+      expect(() async => await getAndParseFinchExportForJourneys(mockImport), throwsA("Failed to read file, zip is empty."));
+    });
   });
 }


### PR DESCRIPTION
### Overview

Add support for importing journeys from a Finch export.

### Changes in this PR

- Parse the imported zip file for journeys.
- Once journeys are imported, display the number of journeys in a toaster.
- Basic unit test for empty export zip file.
