### PR TITLE
Hive box should not use dynamic types

### DIFF
--- a/lib/common/constants.dart
+++ b/lib/common/constants.dart
@@ -1,1 +1,10 @@
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../model/report.dart';
+
 const zebraBox = "ZebraBox";
+
+ValueListenable<Box<List<Report>>> getZebraBox() {
+  return Hive.box<List<Report>>(zebraBox).listenable();
+}

--- a/lib/widgets/insights/heatmap.dart
+++ b/lib/widgets/insights/heatmap.dart
@@ -1,7 +1,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_heatmap_calendar/flutter_heatmap_calendar.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
@@ -20,7 +19,7 @@ class GoalsHeatMap extends StatelessWidget {
     return Consumer<GoalsModel>(
       builder: (context, model, child) {
         return ValueListenableBuilder(
-          valueListenable: Hive.box(zebraBox).listenable(),
+          valueListenable: getZebraBox(),
           builder: (context, box, widget) {
             // Render empty box when list of goals is empty.
             if (box.isEmpty) {

--- a/lib/widgets/insights/heatmap_calendar.dart
+++ b/lib/widgets/insights/heatmap_calendar.dart
@@ -1,7 +1,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_heatmap_calendar/flutter_heatmap_calendar.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
@@ -20,7 +19,7 @@ class GoalsHeatMapCalendar extends StatelessWidget {
     return Consumer<GoalsModel>(
       builder: (context, model, child) {
         return ValueListenableBuilder(
-          valueListenable: Hive.box(zebraBox).listenable(),
+          valueListenable: getZebraBox(),
           builder: (context, box, widget) {
             // Render empty box when list of goals is empty.
             if (box.isEmpty) {

--- a/lib/widgets/selector/goal_selector.dart
+++ b/lib/widgets/selector/goal_selector.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:provider/provider.dart';
 
 import '../../common/constants.dart';
@@ -21,7 +20,7 @@ class _GoalSelectorState extends State<GoalSelector> {
     return Consumer<GoalsModel>(
       builder: (context, model, child) {
         return ValueListenableBuilder(
-          valueListenable: Hive.box(zebraBox).listenable(),
+          valueListenable: getZebraBox(),
           builder: (context, box, widget) {
             final goals = box.toMap();
             if (goals.isEmpty) {

--- a/lib/widgets/selector/native_goal_selector.dart
+++ b/lib/widgets/selector/native_goal_selector.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_native_select/flutter_native_select.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:provider/provider.dart';
 
 import '../../common/constants.dart';
@@ -15,7 +14,7 @@ class NativeGoalSelector extends StatelessWidget {
     return Consumer<GoalsModel>(
       builder: (context, model, child) {
         return ValueListenableBuilder(
-          valueListenable: Hive.box(zebraBox).listenable(),
+          valueListenable: getZebraBox(),
           builder: (context, box, widget) {
             // todo remove cast
             final goals = box.toMap();

--- a/lib/widgets/upload_button.dart
+++ b/lib/widgets/upload_button.dart
@@ -53,7 +53,7 @@ class UploadButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder(
-      valueListenable: Hive.box(zebraBox).listenable(),
+      valueListenable: getZebraBox(),
       builder: (context, box, widget) {
         closeDialog() => {
           Navigator.pop(context, 'Cancel')

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -12,13 +12,14 @@ import 'package:hive_test/hive_test.dart';
 import 'package:zebra/common/constants.dart';
 
 import 'package:zebra/main.dart';
+import 'package:zebra/model/report.dart';
 
 void main() {
   Box? box;
 
   setUp(() async {
     await setUpTestHive();
-    box = await Hive.openBox(zebraBox);
+    box = await Hive.openBox<List<Report>>(zebraBox);
     // todo add some testing data
     // have to put the call inside a `runAsync()`
     // await tester.runAsync(() => box.put('key', 'hello world'));


### PR DESCRIPTION
### Overview

Hive box should only be used parameterized for type safety.

Further reading https://docs.hivedb.dev/#/basics/boxes?id=type-parameter-boxltegt

### Changes in this PR

- Utility function to open the main hive box.
- All usages of the hive box should use these utility functions.