### PR TITLE
Add type safety to hive connection

### DIFF
--- a/lib/common/constants.dart
+++ b/lib/common/constants.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/foundation.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
-import '../model/report.dart';
+import '../model/main.dart';
 
 const zebraBox = "ZebraBox";
 
-ValueListenable<Box<List<Report>>> getZebraBox() {
-  return Hive.box<List<Report>>(zebraBox).listenable();
+ValueListenable<Box<Main>> getZebraBox() {
+  return Hive.box<Main>(zebraBox).listenable();
 }

--- a/lib/common/constants.dart
+++ b/lib/common/constants.dart
@@ -1,1 +1,10 @@
+import 'package:flutter/foundation.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../model/report.dart';
+
 const zebraBox = "ZebraBox";
+
+ValueListenable<Box<List<Report>>> getZebraBox() {
+  return Hive.box<List<Report>>(zebraBox).listenable();
+}

--- a/lib/common/constants.dart
+++ b/lib/common/constants.dart
@@ -3,7 +3,10 @@ import 'package:hive_flutter/hive_flutter.dart';
 
 import '../model/main.dart';
 
+/// Name of the Hive box used by Zebra.
 const zebraBox = "ZebraBox";
+/// Key of the global main application state.
+const mainKey = "main";
 
 ValueListenable<Box<Main>> getZebraBox() {
   return Hive.box<Main>(zebraBox).listenable();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'widgets/home.dart';
 
 void main() async {
   Hive.registerAdapter(ReportAdapter()); 
+  Hive.registerAdapter(MainAdapter()); 
   await Hive.initFlutter();
   await Hive.openBox<Main>(zebraBox);
   runApp(const ZebraApp());

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,13 +3,14 @@ import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import 'common/constants.dart';
+import 'model/main.dart';
 import 'model/report.dart';
 import 'widgets/home.dart';
 
 void main() async {
   Hive.registerAdapter(ReportAdapter()); 
   await Hive.initFlutter();
-  await Hive.openBox<List<Report>>(zebraBox);
+  await Hive.openBox<Main>(zebraBox);
   runApp(const ZebraApp());
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,7 +9,7 @@ import 'widgets/home.dart';
 void main() async {
   Hive.registerAdapter(ReportAdapter()); 
   await Hive.initFlutter();
-  await Hive.openBox(zebraBox);
+  await Hive.openBox<List<Record>>(zebraBox);
   runApp(const ZebraApp());
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,7 +9,7 @@ import 'widgets/home.dart';
 void main() async {
   Hive.registerAdapter(ReportAdapter()); 
   await Hive.initFlutter();
-  await Hive.openBox<List<Record>>(zebraBox);
+  await Hive.openBox<List<Report>>(zebraBox);
   runApp(const ZebraApp());
 }
 

--- a/lib/model/main.dart
+++ b/lib/model/main.dart
@@ -1,0 +1,18 @@
+import 'package:hive_flutter/hive_flutter.dart';
+
+import 'report.dart';
+
+/// This allows the `Main` class to access private members in
+/// the generated file. The value for this is *.g.dart, where
+/// the star denotes the source file name.
+part 'main.g.dart';
+
+/// This class is written to hive, so it needs a type adapter.
+@HiveType(typeId: 1)
+class Main {
+  Main({ required this.goals });
+
+  // @JsonKey(required: true, name: 'date')
+  @HiveField(0)
+  Map<String, List<Report>> goals;
+}

--- a/lib/model/main.dart
+++ b/lib/model/main.dart
@@ -7,12 +7,16 @@ import 'report.dart';
 /// the star denotes the source file name.
 part 'main.g.dart';
 
+/// This is the main data storage object for th3e entire application.
+/// It is stored this way for better type safety.
+/// Ideally, using a box for a list of goals is preferable, but that couldn't be achieved with type safety, as it requires casting.
+/// Update once a better type friendly way is discovered.
+
 /// This class is written to hive, so it needs a type adapter.
-@HiveType(typeId: 1)
+@HiveType(typeId: 2)
 class Main {
   Main({ required this.goals });
 
-  // @JsonKey(required: true, name: 'date')
   @HiveField(0)
   Map<String, List<Report>> goals;
 }

--- a/lib/model/main.g.dart
+++ b/lib/model/main.g.dart
@@ -1,0 +1,42 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'main.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class MainAdapter extends TypeAdapter<Main> {
+  @override
+  final int typeId = 1;
+
+  @override
+  Main read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return Main(
+      goals: (fields[0] as Map).map((dynamic k, dynamic v) =>
+          MapEntry(k as String, (v as List).cast<Report>())),
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, Main obj) {
+    writer
+      ..writeByte(1)
+      ..writeByte(0)
+      ..write(obj.goals);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MainAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/model/main.g.dart
+++ b/lib/model/main.g.dart
@@ -8,7 +8,7 @@ part of 'main.dart';
 
 class MainAdapter extends TypeAdapter<Main> {
   @override
-  final int typeId = 1;
+  final int typeId = 2;
 
   @override
   Main read(BinaryReader reader) {

--- a/lib/model/report.dart
+++ b/lib/model/report.dart
@@ -1,34 +1,20 @@
 import 'package:hive_flutter/hive_flutter.dart';
-import 'package:json_annotation/json_annotation.dart';
 
 /// This allows the `Report` class to access private members in
 /// the generated file. The value for this is *.g.dart, where
 /// the star denotes the source file name.
 part 'report.g.dart';
 
-/// An annotation for the code generator to know that this class needs the
-/// JSON serialization logic to be generated.
-@JsonSerializable(explicitToJson: true)
 /// This class is written to hive, so it needs a type adapter.
 @HiveType(typeId: 1)
 class Report {
   Report(this.date, this.isCompleted);
 
-  @JsonKey(required: true, name: 'date')
+  // @JsonKey(required: true, name: 'date')
   @HiveField(0)
   String date;
 
-  @JsonKey(required: true, name: 'isCompleted')
+  // @JsonKey(required: true, name: 'isCompleted')
   @HiveField(1)
   bool isCompleted;
-
-  /// A necessary factory constructor for creating a new Report instance
-  /// from a map. Pass the map to the generated `_$ReportFromJson()` constructor.
-  /// The constructor is named after the source class, in this case, Report.
-  factory Report.fromJson(Map<String, dynamic> json) => _$ReportFromJson(json);
-
-  /// `toJson` is the convention for a class to declare support for serialization
-  /// to JSON. The implementation simply calls the private, generated
-  /// helper method `_$ReportToJson`.
-  Map<String, dynamic> toJson() => _$ReportToJson(this);
 }

--- a/lib/model/report.dart
+++ b/lib/model/report.dart
@@ -10,11 +10,9 @@ part 'report.g.dart';
 class Report {
   Report({ required this.date, required this.isCompleted });
 
-  // @JsonKey(required: true, name: 'date')
   @HiveField(0)
   String date;
 
-  // @JsonKey(required: true, name: 'isCompleted')
   @HiveField(1)
   bool isCompleted;
 }

--- a/lib/model/report.dart
+++ b/lib/model/report.dart
@@ -8,7 +8,7 @@ part 'report.g.dart';
 /// This class is written to hive, so it needs a type adapter.
 @HiveType(typeId: 1)
 class Report {
-  Report(this.date, this.isCompleted);
+  Report({ required this.date, required this.isCompleted });
 
   // @JsonKey(required: true, name: 'date')
   @HiveField(0)

--- a/lib/model/report.g.dart
+++ b/lib/model/report.g.dart
@@ -42,23 +42,3 @@ class ReportAdapter extends TypeAdapter<Report> {
           runtimeType == other.runtimeType &&
           typeId == other.typeId;
 }
-
-// **************************************************************************
-// JsonSerializableGenerator
-// **************************************************************************
-
-Report _$ReportFromJson(Map<String, dynamic> json) {
-  $checkKeys(
-    json,
-    requiredKeys: const ['date', 'isCompleted'],
-  );
-  return Report(
-    json['date'] as String,
-    json['isCompleted'] as bool,
-  );
-}
-
-Map<String, dynamic> _$ReportToJson(Report instance) => <String, dynamic>{
-      'date': instance.date,
-      'isCompleted': instance.isCompleted,
-    };

--- a/lib/model/report.g.dart
+++ b/lib/model/report.g.dart
@@ -17,8 +17,8 @@ class ReportAdapter extends TypeAdapter<Report> {
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return Report(
-      fields[0] as String,
-      fields[1] as bool,
+      date: fields[0] as String,
+      isCompleted: fields[1] as bool,
     );
   }
 

--- a/lib/widgets/insights/heatmap.dart
+++ b/lib/widgets/insights/heatmap.dart
@@ -1,7 +1,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_heatmap_calendar/flutter_heatmap_calendar.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
@@ -20,7 +19,7 @@ class GoalsHeatMap extends StatelessWidget {
     return Consumer<GoalsModel>(
       builder: (context, model, child) {
         return ValueListenableBuilder(
-          valueListenable: Hive.box(zebraBox).listenable(),
+          valueListenable: getZebraBox(),
           builder: (context, box, widget) {
             // Render empty box when list of goals is empty.
             if (box.isEmpty) {

--- a/lib/widgets/insights/heatmap.dart
+++ b/lib/widgets/insights/heatmap.dart
@@ -29,7 +29,7 @@ class GoalsHeatMap extends StatelessWidget {
             if (model.selectedGoal == null) {
               return const SizedBox();
             }
-            final selectedGoal = box.get(model.selectedGoal);
+            final selectedGoal = box.get('goals')?.goals[model.selectedGoal];
             if (selectedGoal == null) {
               throw "Selected goal does not exist";
             }

--- a/lib/widgets/insights/heatmap.dart
+++ b/lib/widgets/insights/heatmap.dart
@@ -29,7 +29,7 @@ class GoalsHeatMap extends StatelessWidget {
             if (model.selectedGoal == null) {
               return const SizedBox();
             }
-            final selectedGoal = box.get('goals')?.goals[model.selectedGoal];
+            final selectedGoal = box.get(mainKey)?.goals[model.selectedGoal];
             if (selectedGoal == null) {
               throw "Selected goal does not exist";
             }

--- a/lib/widgets/insights/heatmap_calendar.dart
+++ b/lib/widgets/insights/heatmap_calendar.dart
@@ -29,7 +29,7 @@ class GoalsHeatMapCalendar extends StatelessWidget {
             if (model.selectedGoal == null) {
               return const SizedBox();
             }
-            final selectedGoal = box.get('goals')?.goals[model.selectedGoal];
+            final selectedGoal = box.get(mainKey)?.goals[model.selectedGoal];
             if (selectedGoal == null) {
               throw "Selected goal does not exist";
             }

--- a/lib/widgets/insights/heatmap_calendar.dart
+++ b/lib/widgets/insights/heatmap_calendar.dart
@@ -29,7 +29,7 @@ class GoalsHeatMapCalendar extends StatelessWidget {
             if (model.selectedGoal == null) {
               return const SizedBox();
             }
-            final selectedGoal = box.get(model.selectedGoal);
+            final selectedGoal = box.get('goals')?.goals[model.selectedGoal];
             if (selectedGoal == null) {
               throw "Selected goal does not exist";
             }

--- a/lib/widgets/insights/heatmap_calendar.dart
+++ b/lib/widgets/insights/heatmap_calendar.dart
@@ -1,7 +1,6 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_heatmap_calendar/flutter_heatmap_calendar.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
@@ -20,7 +19,7 @@ class GoalsHeatMapCalendar extends StatelessWidget {
     return Consumer<GoalsModel>(
       builder: (context, model, child) {
         return ValueListenableBuilder(
-          valueListenable: Hive.box(zebraBox).listenable(),
+          valueListenable: getZebraBox(),
           builder: (context, box, widget) {
             // Render empty box when list of goals is empty.
             if (box.isEmpty) {

--- a/lib/widgets/selector/goal_selector.dart
+++ b/lib/widgets/selector/goal_selector.dart
@@ -22,7 +22,7 @@ class _GoalSelectorState extends State<GoalSelector> {
         return ValueListenableBuilder(
           valueListenable: getZebraBox(),
           builder: (context, box, widget) {
-            final goals = box.get('goals')?.goals;
+            final goals = box.get(mainKey)?.goals;
             if (goals == null || goals.isEmpty) {
               // Render empty box when list of goals is empty.
               return const SizedBox();

--- a/lib/widgets/selector/goal_selector.dart
+++ b/lib/widgets/selector/goal_selector.dart
@@ -22,8 +22,8 @@ class _GoalSelectorState extends State<GoalSelector> {
         return ValueListenableBuilder(
           valueListenable: getZebraBox(),
           builder: (context, box, widget) {
-            final goals = box.toMap();
-            if (goals.isEmpty) {
+            final goals = box.get('goals')?.goals;
+            if (goals == null || goals.isEmpty) {
               // Render empty box when list of goals is empty.
               return const SizedBox();
             }

--- a/lib/widgets/selector/goal_selector.dart
+++ b/lib/widgets/selector/goal_selector.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:provider/provider.dart';
 
 import '../../common/constants.dart';
@@ -21,7 +20,7 @@ class _GoalSelectorState extends State<GoalSelector> {
     return Consumer<GoalsModel>(
       builder: (context, model, child) {
         return ValueListenableBuilder(
-          valueListenable: Hive.box(zebraBox).listenable(),
+          valueListenable: getZebraBox(),
           builder: (context, box, widget) {
             final goals = box.toMap();
             if (goals.isEmpty) {

--- a/lib/widgets/selector/native_goal_selector.dart
+++ b/lib/widgets/selector/native_goal_selector.dart
@@ -17,8 +17,7 @@ class NativeGoalSelector extends StatelessWidget {
         return ValueListenableBuilder(
           valueListenable: getZebraBox(),
           builder: (context, box, widget) {
-            // todo remove cast
-            final goals = box.get('goals')?.goals;
+            final goals = box.get(mainKey)?.goals;
             return _GoalSelectorInternal(goals, model.selectedGoal, model.setSelectedGoal);
           }
         );

--- a/lib/widgets/selector/native_goal_selector.dart
+++ b/lib/widgets/selector/native_goal_selector.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_native_select/flutter_native_select.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:provider/provider.dart';
 
 import '../../common/constants.dart';
@@ -15,7 +14,7 @@ class NativeGoalSelector extends StatelessWidget {
     return Consumer<GoalsModel>(
       builder: (context, model, child) {
         return ValueListenableBuilder(
-          valueListenable: Hive.box(zebraBox).listenable(),
+          valueListenable: getZebraBox(),
           builder: (context, box, widget) {
             // todo remove cast
             final goals = box.toMap();

--- a/lib/widgets/selector/native_goal_selector.dart
+++ b/lib/widgets/selector/native_goal_selector.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 
 import '../../common/constants.dart';
 import '../../model/goals.dart';
+import '../../model/report.dart';
 
 /// Widget to display a native selector for a list of goals.
 class NativeGoalSelector extends StatelessWidget {
@@ -17,7 +18,7 @@ class NativeGoalSelector extends StatelessWidget {
           valueListenable: getZebraBox(),
           builder: (context, box, widget) {
             // todo remove cast
-            final goals = box.toMap();
+            final goals = box.get('goals')?.goals;
             return _GoalSelectorInternal(goals, model.selectedGoal, model.setSelectedGoal);
           }
         );
@@ -26,7 +27,7 @@ class NativeGoalSelector extends StatelessWidget {
   }
 }
 class _GoalSelectorInternal extends StatelessWidget {
-  final Map<dynamic, dynamic> goals;
+  final Map<String, List<Report>>? goals;
   final String? selectedGoal;
   final void Function(String?) onSelected;
 
@@ -34,15 +35,15 @@ class _GoalSelectorInternal extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-      if (goals.isEmpty) {
+      if (goals == null || goals!.isEmpty) {
         // Render empty box when list of goals is empty.
         return const SizedBox();
       }
-      final List<String> keys = List.from(goals.keys);
+      final List<String> keys = List.from(goals!.keys);
       // Sort keys by number of reports.
       keys.sort((a, b) {
-        final aGoal = goals[a]!;
-        final bGoal = goals[b]!;
+        final aGoal = goals![a]!;
+        final bGoal = goals![b]!;
         return bGoal.length - aGoal.length;
       });
       return ElevatedButton.icon(

--- a/lib/widgets/upload_button.dart
+++ b/lib/widgets/upload_button.dart
@@ -6,6 +6,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 
 import '../common/constants.dart';
 import '../common/util.dart';
+import '../model/main.dart';
 import '../model/report.dart';
 
 
@@ -14,7 +15,7 @@ import '../model/report.dart';
 class UploadButton extends StatelessWidget {
   const UploadButton({super.key});
 
-  Future<void> import(Box box) async {
+  Future<void> import(Box<Main> box) async {
     try {
       FilePickerResult? result = await FilePicker.platform.pickFiles(type: FileType.custom, allowedExtensions: ["zip"], withData: true );
       final goals = await getAndParseFinchExport(result);
@@ -31,8 +32,8 @@ class UploadButton extends StatelessWidget {
           reports[key]?.add(Report(date: g.date, isCompleted: g.completedTime != ""));
         }
       }
-      await box.clear();
-      await box.put('goals', reports);
+      await box.delete(mainKey);
+      await box.put(mainKey, Main(goals: reports));
       Fluttertoast.showToast(
         msg: "Imported",
         toastLength: Toast.LENGTH_SHORT,

--- a/lib/widgets/upload_button.dart
+++ b/lib/widgets/upload_button.dart
@@ -28,7 +28,7 @@ class UploadButton extends StatelessWidget {
           reports[key] = [];
         }
         for (var g in goal) {
-          reports[key]?.add(Report(g.date, g.completedTime != ""));
+          reports[key]?.add(Report(date: g.date, isCompleted: g.completedTime != ""));
         }
       }
       await box.clear();

--- a/lib/widgets/upload_button.dart
+++ b/lib/widgets/upload_button.dart
@@ -53,7 +53,7 @@ class UploadButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder(
-      valueListenable: Hive.box(zebraBox).listenable(),
+      valueListenable: getZebraBox(),
       builder: (context, box, widget) {
         closeDialog() => {
           Navigator.pop(context, 'Cancel')

--- a/lib/widgets/upload_button.dart
+++ b/lib/widgets/upload_button.dart
@@ -32,7 +32,7 @@ class UploadButton extends StatelessWidget {
         }
       }
       await box.clear();
-      await box.putAll(reports);
+      await box.put('goals', reports);
       Fluttertoast.showToast(
         msg: "Imported",
         toastLength: Toast.LENGTH_SHORT,

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -12,13 +12,14 @@ import 'package:hive_test/hive_test.dart';
 import 'package:zebra/common/constants.dart';
 
 import 'package:zebra/main.dart';
+import 'package:zebra/model/report.dart';
 
 void main() {
   Box? box;
 
   setUp(() async {
     await setUpTestHive();
-    box = await Hive.openBox(zebraBox);
+    box = await Hive.openBox<List<Report>>(zebraBox);
     // todo add some testing data
     // have to put the call inside a `runAsync()`
     // await tester.runAsync(() => box.put('key', 'hello world'));

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -12,14 +12,14 @@ import 'package:hive_test/hive_test.dart';
 import 'package:zebra/common/constants.dart';
 
 import 'package:zebra/main.dart';
-import 'package:zebra/model/report.dart';
+import 'package:zebra/model/main.dart';
 
 void main() {
   Box? box;
 
   setUp(() async {
     await setUpTestHive();
-    box = await Hive.openBox<List<Report>>(zebraBox);
+    box = await Hive.openBox<Main>(zebraBox);
     // todo add some testing data
     // have to put the call inside a `runAsync()`
     // await tester.runAsync(() => box.put('key', 'hello world'));


### PR DESCRIPTION
### Overview

Hive box should only be used parameterized for type safety.

Further reading https://docs.hivedb.dev/#/basics/boxes?id=type-parameter-boxltegt

### Changes in this PR

- Utility function to open the main hive box.
- All usages of the hive box should use these utility functions.
- Main global state saved under a main global contant.
- Global state represented by new class `Main`.

### Workflow fixed

- Page refresh, when data is read from hive, page load does not crash.
