### PR TITLE
Adding navigation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,22 @@
 
 import "package:flutter/material.dart";
+import "package:go_router/go_router.dart";
 import "package:hive_flutter/hive_flutter.dart";
 
 import "common/constants.dart";
 import "model/main.dart";
 import "model/report.dart";
 import "widgets/home.dart";
+
+// GoRouter configuration
+final _router = GoRouter(
+  routes: [
+    GoRoute(
+      path: "/",
+      builder: (context, state) => const ZebraHomePage(),
+    ),
+  ],
+);
 
 void main() async {
   Hive.registerAdapter(ReportAdapter()); 
@@ -20,12 +31,17 @@ class ZebraApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+<<<<<<< HEAD
     return MaterialApp(
       title: "Zebra",
+=======
+    return MaterialApp.router(
+      routerConfig: _router,
+      title: 'Zebra',
+>>>>>>> 4a56a16 (Add home navigation)
       theme: ThemeData(
         primaryColor: const Color.fromARGB(100, 65, 180, 255),
       ),
-      home: const ZebraHomePage(),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,11 +15,13 @@ final _router = GoRouter(
   routes: [
     GoRoute(
       path: "/",
+      name: "home",
       builder: (context, state) => const ZebraHomePage(),
     ),
     GoRoute(
-      path: "/goals",
-      builder: (context, state) => GoalPage(goRouterState: state,),
+      name: "goal",
+      path: "/goals/:goal_name",
+      builder: (context, state) => GoalPage(goalName: state.pathParameters["goal_name"] ?? "No goal found",),
     ),
   ],
 );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import "common/constants.dart";
 import "model/main.dart";
 import "model/report.dart";
 import "widgets/home.dart";
+import "widgets/pages/goal.dart";
 
 // GoRouter configuration
 final _router = GoRouter(
@@ -14,6 +15,10 @@ final _router = GoRouter(
     GoRoute(
       path: "/",
       builder: (context, state) => const ZebraHomePage(),
+    ),
+    GoRoute(
+      path: "/goals",
+      builder: (context, state) => GoalPage(goRouterState: state,),
     ),
   ],
 );
@@ -31,14 +36,9 @@ class ZebraApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-<<<<<<< HEAD
-    return MaterialApp(
-      title: "Zebra",
-=======
     return MaterialApp.router(
       routerConfig: _router,
-      title: 'Zebra',
->>>>>>> 4a56a16 (Add home navigation)
+      title: "Zebra",
       theme: ThemeData(
         primaryColor: const Color.fromARGB(100, 65, 180, 255),
       ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@
 import "package:flutter/material.dart";
 import "package:go_router/go_router.dart";
 import "package:hive_flutter/hive_flutter.dart";
+import "package:url_strategy/url_strategy.dart";
 
 import "common/constants.dart";
 import "model/main.dart";
@@ -24,6 +25,8 @@ final _router = GoRouter(
 );
 
 void main() async {
+  setPathUrlStrategy();
+
   Hive.registerAdapter(ReportAdapter()); 
   Hive.registerAdapter(MainAdapter()); 
   await Hive.initFlutter();

--- a/lib/widgets/common/goal.dart
+++ b/lib/widgets/common/goal.dart
@@ -1,5 +1,6 @@
 
 import "package:flutter/material.dart";
+import "package:go_router/go_router.dart";
 
 import "../../model/report.dart";
 import "goal_name.dart";
@@ -18,7 +19,7 @@ class Goal extends StatelessWidget {
       margin: const EdgeInsets.only(bottom: 3),
       child: ElevatedButton(
         onPressed: () {
-          // navigator.push(route)
+          GoRouter.of(context).goNamed("goal", pathParameters: {"goal_name": goalName});
         },
         style: ElevatedButton.styleFrom(
           backgroundColor: Theme.of(context).primaryColor,

--- a/lib/widgets/common/goal.dart
+++ b/lib/widgets/common/goal.dart
@@ -12,12 +12,31 @@ class Goal extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // final navigator = Navigator.of(context);
     return Container(
-      height: 50,
+      // We need to wrap button in container because we can't set margins.
       margin: const EdgeInsets.only(bottom: 3),
-      color: Theme.of(context).primaryColor,
-      child: Center(child: GoalName(completion: reports.length, goalName: goalName,)),
+      child: ElevatedButton(
+        onPressed: () {
+          // navigator.push(route)
+        },
+        style: ElevatedButton.styleFrom(
+          backgroundColor: Theme.of(context).primaryColor,
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+          shape: const RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(2)),
+          ),
+        ),
+        child: GoalName(completion: reports.length, goalName: goalName,)
+      )
     );
+    // return Container(
+    //   height: 50,
+    //   margin: const EdgeInsets.only(bottom: 3),
+    //   color: Theme.of(context).primaryColor,
+    //   child: Center(child: GoalName(completion: reports.length, goalName: goalName,)),
+    // );
   }
 }
 

--- a/lib/widgets/pages/goal.dart
+++ b/lib/widgets/pages/goal.dart
@@ -1,0 +1,25 @@
+
+import "package:flutter/material.dart";
+import "package:go_router/go_router.dart";
+import "package:provider/provider.dart";
+
+import "../../model/goals.dart";
+
+class GoalPage extends StatelessWidget {
+  final GoRouterState? goRouterState;
+
+  const GoalPage({super.key, required this.goRouterState});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (context) => GoalsModel(),
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text("Zebra"),
+        ),
+        body: Text(goRouterState?.pathParameters["goal_name"] ?? "No goal found."),
+      )
+    );
+  }
+}

--- a/lib/widgets/pages/goal.dart
+++ b/lib/widgets/pages/goal.dart
@@ -1,14 +1,13 @@
 
 import "package:flutter/material.dart";
-import "package:go_router/go_router.dart";
 import "package:provider/provider.dart";
 
 import "../../model/goals.dart";
 
 class GoalPage extends StatelessWidget {
-  final GoRouterState? goRouterState;
+  final String? goalName;
 
-  const GoalPage({super.key, required this.goRouterState});
+  const GoalPage({super.key, required this.goalName});
 
   @override
   Widget build(BuildContext context) {
@@ -18,7 +17,7 @@ class GoalPage extends StatelessWidget {
         appBar: AppBar(
           title: const Text("Zebra"),
         ),
-        body: Text(goRouterState?.pathParameters["goal_name"] ?? "No goal found."),
+        body: Text(goalName ?? "No goal found."),
       )
     );
   }

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,9 @@ import FlutterMacOS
 import Foundation
 
 import path_provider_foundation
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -304,6 +304,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: "2ddb88e9ad56ae15ee144ed10e33886777eb5ca2509a914850a5faa7b52ff459"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.2.7"
   graphs:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -781,6 +781,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  url_strategy:
+    dependency: "direct main"
+    description:
+      name: url_strategy
+      sha256: "6eff69fa0900b731a23552b38b54389f399d247dbb0998f2cbdf25bef6790a7c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -717,6 +717,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: "21b704ce5fa560ea9f3b525b43601c678728ba46725bab9b01187b4831377ed3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.0"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: f0c73347dfcfa5b3db8bc06e1502668265d39c08f310c29bff4e28eea9699f79
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.9"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: e43b677296fadce447e987a2f519dcf5f6d1e527dc35d01ffab4fff5b8a7063e
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: e2b9622b4007f97f504cd64c0128309dfb978ae66adbe944125ed9e1750f06af
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "9a1a42d5d2d95400c795b2914c36fdcb525870c752569438e4ebb09a2b5d90de"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "772638d3b34c779ede05ba3d38af34657a05ac55b06279ea6edd409e323dca8e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.3"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "49c10f879746271804767cb45551ec5592cdab00ee105c06dddde1a98f73b185"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   hive: ^2.2.3
   hive_flutter: ^1.1.0
   flutter_native_select: ^1.0.1
+  go_router: ^14.2.7
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   hive_flutter: ^1.1.0
   flutter_native_select: ^1.0.1
   go_router: ^14.2.7
+  url_launcher: ^6.3.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   flutter_native_select: ^1.0.1
   go_router: ^14.2.7
   url_launcher: ^6.3.0
+  url_strategy: ^0.3.0
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,9 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
### Overview

Started using navigation in the app using `go_router`. User can now navigate to a goal page from the list of goals page.

### Changes in this PR

- Added dependency on `go_router` and `url_strategy`.
- `go_router` used for basic navigation https://pub.dev/documentation/go_router/latest/topics/Navigation-topic.html
- `url_strategy` is added for `setPathUrlStrategy`, avoiding `#` in the url. Called in the main function.
- Clicking on a goal navigates to the goal page.