### PR TITLE
Enable prefer_double_quotes lint rule

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "editor.codeActionsOnSave": {
+        "source.fixAll": "always"
+    },
+}

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -26,12 +26,16 @@ linter:
     directives_ordering: true
     # avoid root imports https://dart.dev/tools/linter-rules/prefer_relative_imports
     prefer_relative_imports: true
+    # use double quotes when possible
+    prefer_double_quotes: true
 
 analyzer:
   errors:
     unused_local_variable: error
     use_key_in_widget_constructors: error
     prefer_const_constructors: error
+  exclude: 
+    - '**/*.g.dart'
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/lib/common/constants.dart
+++ b/lib/common/constants.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/foundation.dart';
-import 'package:hive_flutter/hive_flutter.dart';
+import "package:flutter/foundation.dart";
+import "package:hive_flutter/hive_flutter.dart";
 
-import '../model/main.dart';
+import "../model/main.dart";
 
 /// Name of the Hive box used by Zebra.
 const zebraBox = "ZebraBox";

--- a/lib/common/util.dart
+++ b/lib/common/util.dart
@@ -1,8 +1,8 @@
-import 'dart:convert';
+import "dart:convert";
 
-import 'package:archive/archive.dart';
-import 'package:file_picker/file_picker.dart';
-import '../model/goal.dart';
+import "package:archive/archive.dart";
+import "package:file_picker/file_picker.dart";
+import "../model/goal.dart";
 
 /// Function that parses Finch zip export file and updates the goals model.
 Future<Map<String, List<Goal>>> getAndParseFinchExport(FilePickerResult? result) async {
@@ -20,7 +20,7 @@ Future<Map<String, List<Goal>>> getAndParseFinchExport(FilePickerResult? result)
       // Goals are stored in Bullet.json
       if (file.isFile && file.name == "Bullet.json") {
         final goalBytes = file.content as List<int>;
-        final goalsRaw = (jsonDecode(utf8.decode(goalBytes)) as Map<String, dynamic>)['data'];
+        final goalsRaw = (jsonDecode(utf8.decode(goalBytes)) as Map<String, dynamic>)["data"];
         final goals = <String, List<Goal>>{};
         for (var goal in goalsRaw) {
           final g = Goal.fromJson(goal);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,11 @@
 
-import 'package:flutter/material.dart';
-import 'package:hive_flutter/hive_flutter.dart';
+import "package:flutter/material.dart";
+import "package:hive_flutter/hive_flutter.dart";
 
-import 'common/constants.dart';
-import 'model/main.dart';
-import 'model/report.dart';
-import 'widgets/home.dart';
+import "common/constants.dart";
+import "model/main.dart";
+import "model/report.dart";
+import "widgets/home.dart";
 
 void main() async {
   Hive.registerAdapter(ReportAdapter()); 
@@ -21,7 +21,7 @@ class ZebraApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Zebra',
+      title: "Zebra",
       theme: ThemeData(
         primaryColor: const Color.fromARGB(100, 65, 180, 255),
       ),

--- a/lib/model/cadence.dart
+++ b/lib/model/cadence.dart
@@ -1,9 +1,9 @@
-import 'package:json_annotation/json_annotation.dart';
+import "package:json_annotation/json_annotation.dart";
 
 /// This allows the `Cadence` class to access private members in
 /// the generated file. The value for this is *.g.dart, where
 /// the star denotes the source file name.
-part 'cadence.g.dart';
+part "cadence.g.dart";
 
 /// An annotation for the code generator to know that this class needs the
 /// JSON serialization logic to be generated.
@@ -11,7 +11,7 @@ part 'cadence.g.dart';
 class Cadence {
   Cadence(this.periodFrequency);
 
-  @JsonKey(required: false, name: 'period_frequency')
+  @JsonKey(required: false, name: "period_frequency")
   int? periodFrequency;
 
   /// A necessary factory constructor for creating a new Cadence instance

--- a/lib/model/goal.dart
+++ b/lib/model/goal.dart
@@ -1,11 +1,11 @@
-import 'package:json_annotation/json_annotation.dart';
+import "package:json_annotation/json_annotation.dart";
 
-import 'cadence.dart';
+import "cadence.dart";
 
 /// This allows the `Goal` class to access private members in
 /// the generated file. The value for this is *.g.dart, where
 /// the star denotes the source file name.
-part 'goal.g.dart';
+part "goal.g.dart";
 
 /// An annotation for the code generator to know that this class needs the
 /// JSON serialization logic to be generated.
@@ -13,19 +13,19 @@ part 'goal.g.dart';
 class Goal {
   Goal(this.name, this.date, this.completedTime, this.scheduleTime, this.cadence);
 
-  @JsonKey(required: true, name: 'text')
+  @JsonKey(required: true, name: "text")
   String name;
 
-  @JsonKey(required: true, name: 'dt')
+  @JsonKey(required: true, name: "dt")
   String date;
 
-  @JsonKey(required: true, name: 'completed_time')
+  @JsonKey(required: true, name: "completed_time")
   String completedTime;
 
-  @JsonKey(required: true, name: 'schedule_time')
+  @JsonKey(required: true, name: "schedule_time")
   String scheduleTime;
 
-  @JsonKey(required: false, name: 'cadence')
+  @JsonKey(required: false, name: "cadence")
   Cadence? cadence;
 
   /// A necessary factory constructor for creating a new Goal instance

--- a/lib/model/goals.dart
+++ b/lib/model/goals.dart
@@ -1,6 +1,6 @@
 
 
-import 'package:flutter/material.dart';
+import "package:flutter/material.dart";
 
 
 class GoalsModel extends ChangeNotifier {

--- a/lib/model/main.dart
+++ b/lib/model/main.dart
@@ -1,11 +1,11 @@
-import 'package:hive_flutter/hive_flutter.dart';
+import "package:hive_flutter/hive_flutter.dart";
 
-import 'report.dart';
+import "report.dart";
 
 /// This allows the `Main` class to access private members in
 /// the generated file. The value for this is *.g.dart, where
 /// the star denotes the source file name.
-part 'main.g.dart';
+part "main.g.dart";
 
 /// This is the main data storage object for th3e entire application.
 /// It is stored this way for better type safety.

--- a/lib/model/report.dart
+++ b/lib/model/report.dart
@@ -1,9 +1,9 @@
-import 'package:hive_flutter/hive_flutter.dart';
+import "package:hive_flutter/hive_flutter.dart";
 
 /// This allows the `Report` class to access private members in
 /// the generated file. The value for this is *.g.dart, where
 /// the star denotes the source file name.
-part 'report.g.dart';
+part "report.g.dart";
 
 /// This class is written to hive, so it needs a type adapter.
 @HiveType(typeId: 1)

--- a/lib/widgets/card.dart
+++ b/lib/widgets/card.dart
@@ -1,5 +1,5 @@
 
-import 'package:flutter/material.dart';
+import "package:flutter/material.dart";
 
 /// A container widget that scrolls.
 class Card extends StatelessWidget {

--- a/lib/widgets/common/goal.dart
+++ b/lib/widgets/common/goal.dart
@@ -1,8 +1,8 @@
 
-import 'package:flutter/material.dart';
+import "package:flutter/material.dart";
 
-import '../../model/report.dart';
-import 'goal_name.dart';
+import "../../model/report.dart";
+import "goal_name.dart";
 
 class Goal extends StatelessWidget {
   final String goalName;

--- a/lib/widgets/common/goal_name.dart
+++ b/lib/widgets/common/goal_name.dart
@@ -1,5 +1,5 @@
 
-import 'package:flutter/material.dart';
+import "package:flutter/material.dart";
 
 class GoalName extends StatelessWidget {
   final String goalName;

--- a/lib/widgets/home.dart
+++ b/lib/widgets/home.dart
@@ -1,10 +1,10 @@
 
-import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import "package:flutter/material.dart";
+import "package:provider/provider.dart";
 
-import '../model/goals.dart';
-import 'pages/goals.dart';
-import 'upload_button.dart';
+import "../model/goals.dart";
+import "pages/goals.dart";
+import "upload_button.dart";
 
 class ZebraHomePage extends StatelessWidget {
   const ZebraHomePage({super.key});
@@ -15,7 +15,7 @@ class ZebraHomePage extends StatelessWidget {
       create: (context) => GoalsModel(),
       child: Scaffold(
         appBar: AppBar(
-          title: const Text('Zebra'),
+          title: const Text("Zebra"),
         ),
         body: const GoalsPage(),
         floatingActionButton: const UploadButton(),

--- a/lib/widgets/insights/heatmap.dart
+++ b/lib/widgets/insights/heatmap.dart
@@ -1,11 +1,11 @@
 
-import 'package:flutter/material.dart';
-import 'package:flutter_heatmap_calendar/flutter_heatmap_calendar.dart';
-import 'package:intl/intl.dart';
-import 'package:provider/provider.dart';
+import "package:flutter/material.dart";
+import "package:flutter_heatmap_calendar/flutter_heatmap_calendar.dart";
+import "package:intl/intl.dart";
+import "package:provider/provider.dart";
 
-import '../../common/constants.dart';
-import '../../model/goals.dart';
+import "../../common/constants.dart";
+import "../../model/goals.dart";
 
 // Thu, 9 Nov 2023 01:00:00
 DateFormat format = DateFormat("E, d LLL y");

--- a/lib/widgets/insights/heatmap_calendar.dart
+++ b/lib/widgets/insights/heatmap_calendar.dart
@@ -1,11 +1,11 @@
 
-import 'package:flutter/material.dart';
-import 'package:flutter_heatmap_calendar/flutter_heatmap_calendar.dart';
-import 'package:intl/intl.dart';
-import 'package:provider/provider.dart';
+import "package:flutter/material.dart";
+import "package:flutter_heatmap_calendar/flutter_heatmap_calendar.dart";
+import "package:intl/intl.dart";
+import "package:provider/provider.dart";
 
-import '../../common/constants.dart';
-import '../../model/goals.dart';
+import "../../common/constants.dart";
+import "../../model/goals.dart";
 
 // Thu, 9 Nov 2023 01:00:00
 DateFormat format = DateFormat("E, d LLL y");

--- a/lib/widgets/pages/goals.dart
+++ b/lib/widgets/pages/goals.dart
@@ -1,8 +1,8 @@
 
-import 'package:flutter/material.dart';
+import "package:flutter/material.dart";
 
-import '../../common/constants.dart';
-import '../common/goal.dart';
+import "../../common/constants.dart";
+import "../common/goal.dart";
 
 class GoalsPage extends StatelessWidget {
   const GoalsPage({super.key});

--- a/lib/widgets/selector/goal_selector.dart
+++ b/lib/widgets/selector/goal_selector.dart
@@ -1,8 +1,8 @@
-import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import "package:flutter/material.dart";
+import "package:provider/provider.dart";
 
-import '../../common/constants.dart';
-import '../../model/goals.dart';
+import "../../common/constants.dart";
+import "../../model/goals.dart";
 
 /// Widget to display a selector for a list of goals.
 class GoalSelector extends StatefulWidget {

--- a/lib/widgets/selector/native_goal_selector.dart
+++ b/lib/widgets/selector/native_goal_selector.dart
@@ -1,10 +1,10 @@
-import 'package:flutter/material.dart';
-import 'package:flutter_native_select/flutter_native_select.dart';
-import 'package:provider/provider.dart';
+import "package:flutter/material.dart";
+import "package:flutter_native_select/flutter_native_select.dart";
+import "package:provider/provider.dart";
 
-import '../../common/constants.dart';
-import '../../model/goals.dart';
-import '../../model/report.dart';
+import "../../common/constants.dart";
+import "../../model/goals.dart";
+import "../../model/report.dart";
 
 /// Widget to display a native selector for a list of goals.
 class NativeGoalSelector extends StatelessWidget {

--- a/lib/widgets/upload_button.dart
+++ b/lib/widgets/upload_button.dart
@@ -1,13 +1,13 @@
 
-import 'package:file_picker/file_picker.dart';
-import 'package:flutter/material.dart';
-import 'package:fluttertoast/fluttertoast.dart';
-import 'package:hive_flutter/hive_flutter.dart';
+import "package:file_picker/file_picker.dart";
+import "package:flutter/material.dart";
+import "package:fluttertoast/fluttertoast.dart";
+import "package:hive_flutter/hive_flutter.dart";
 
-import '../common/constants.dart';
-import '../common/util.dart';
-import '../model/main.dart';
-import '../model/report.dart';
+import "../common/constants.dart";
+import "../common/util.dart";
+import "../model/main.dart";
+import "../model/report.dart";
 
 
 /// Widget that display an upload button that accepts Finch backup zip file.
@@ -57,7 +57,7 @@ class UploadButton extends StatelessWidget {
       valueListenable: getZebraBox(),
       builder: (context, box, widget) {
         closeDialog() => {
-          Navigator.pop(context, 'Cancel')
+          Navigator.pop(context, "Cancel")
         };
         final onPressed = box.isEmpty ? (
           () => import(box)
@@ -65,19 +65,19 @@ class UploadButton extends StatelessWidget {
           () => showDialog<String>(
             context: context,
             builder: (BuildContext context) => AlertDialog(
-              title: const Text('Warning'),
-              content: const Text('Uploading a new export zip file will erase any existing data. Are you sure you want to continue importing a new file?'),
+              title: const Text("Warning"),
+              content: const Text("Uploading a new export zip file will erase any existing data. Are you sure you want to continue importing a new file?"),
               actions: <Widget>[
                 TextButton(
                   onPressed: closeDialog,
-                  child: const Text('Cancel'),
+                  child: const Text("Cancel"),
                 ),
                 TextButton(
                   onPressed: () async { 
                     await import(box);
                     closeDialog();
                   },
-                  child: const Text('Import'),
+                  child: const Text("Import"),
                 ),
               ],
             ),
@@ -85,7 +85,7 @@ class UploadButton extends StatelessWidget {
         );
         return FloatingActionButton(
           onPressed: onPressed,
-          tooltip: 'Upload',
+          tooltip: "Upload",
           child: const Icon(Icons.add),
         );
       }

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -4,22 +4,22 @@
 // utility in the flutter_test package. For example, you can send tap and scroll
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
-import 'package:file_picker/file_picker.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
-import 'package:zebra/common/util.dart';
+import "package:file_picker/file_picker.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:mocktail/mocktail.dart";
+import "package:zebra/common/util.dart";
 
 class MockImport extends Mock implements FilePickerResult {}
 
 void main() {
   final mockImport = MockImport();
 
-  group('Util functions', () {
-    test('Parse null import correctly', () async {
+  group("Util functions", () {
+    test("Parse null import correctly", () async {
       expect(await getAndParseFinchExport(null), {});
     });
 
-    test('Parse empty import correctly', () async {
+    test("Parse empty import correctly", () async {
       when(() => mockImport.files).thenReturn([]);
       expect(await getAndParseFinchExport(mockImport), {});
     });

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,14 +5,14 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:hive_flutter/hive_flutter.dart';
-import 'package:hive_test/hive_test.dart';
-import 'package:zebra/common/constants.dart';
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:hive_flutter/hive_flutter.dart";
+import "package:hive_test/hive_test.dart";
+import "package:zebra/common/constants.dart";
 
-import 'package:zebra/main.dart';
-import 'package:zebra/model/main.dart';
+import "package:zebra/main.dart";
+import "package:zebra/model/main.dart";
 
 void main() {
   Box? box;
@@ -31,10 +31,10 @@ void main() {
     await tearDownTestHive();
   });
 
-  testWidgets('Basic scaffolding', (WidgetTester tester) async {
+  testWidgets("Basic scaffolding", (WidgetTester tester) async {
     await tester.pumpWidget(const ZebraApp());
 
-    expect(find.text('Zebra'), findsOneWidget);
+    expect(find.text("Zebra"), findsOneWidget);
     expect(find.byIcon(Icons.add), findsOneWidget);
   });
 }


### PR DESCRIPTION
### Overview

Enable a new lint rule to consolidate usage of quotes withing the repo. Add tooling to support enabling this rule (autofix).

### Changes in this PR

- Enable `prefer_double_quotes` rule. https://dart.dev/tools/linter-rules/prefer_double_quotes
- Commit VSCode workspace settings to autofix lint errors.