### PR TITLE
Add calendar view for goal

### DIFF
--- a/lib/widgets/pages/goal.dart
+++ b/lib/widgets/pages/goal.dart
@@ -3,6 +3,7 @@ import "package:flutter/material.dart";
 
 import "../card.dart" as card_widget;
 import "../insights/heatmap.dart";
+import "../insights/heatmap_calendar.dart";
 
 class GoalPage extends StatelessWidget {
   final String? goalName;
@@ -15,8 +16,15 @@ class GoalPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text("Zebra"),
       ),
-      body: goalName != null ? card_widget.Card(
-        child: GoalsHeatMap(goalName: goalName!,)
+      body: goalName != null ? Column(
+        children: [
+          card_widget.Card(
+            child: GoalsHeatMapCalendar(goalName: goalName!,)
+          ),
+          card_widget.Card(
+            child: GoalsHeatMap(goalName: goalName!,)
+          ),
+        ]
       ) : const Text("No goal found."),
     );
   }


### PR DESCRIPTION
### Overview

For each individual goal, display a calendar view of its history.

### Changes in this PR

- Add calendar view widget for a goal.
- Use a column for main page of a goal.