### PR TITLE
Add dedicated goal hive type

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import "package:hive_flutter/hive_flutter.dart";
 import "package:url_strategy/url_strategy.dart";
 
 import "common/constants.dart";
+import "model/hive/goal.dart";
 import "model/hive/main.dart";
 import "model/hive/report.dart";
 import "widgets/home.dart";
@@ -29,6 +30,7 @@ final _router = GoRouter(
 void main() async {
   setPathUrlStrategy();
 
+  Hive.registerAdapter(GoalAdapter()); 
   Hive.registerAdapter(ReportAdapter()); 
   Hive.registerAdapter(MainAdapter()); 
   await Hive.initFlutter();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,8 +21,8 @@ final _router = GoRouter(
     ),
     GoRoute(
       name: "goal",
-      path: "/goals/:goal_name",
-      builder: (context, state) => GoalPage(goalName: state.pathParameters["goal_name"] ?? "No goal found",),
+      path: "/goals/:id",
+      builder: (context, state) => GoalPage(goalName: state.pathParameters["id"] ?? "No goal found",),
     ),
   ],
 );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,7 +22,7 @@ final _router = GoRouter(
     GoRoute(
       name: "goal",
       path: "/goals/:id",
-      builder: (context, state) => GoalPage(goalName: state.pathParameters["id"] ?? "No goal found",),
+      builder: (context, state) => GoalPage(id: state.pathParameters["id"] ?? "No goal found",),
     ),
   ],
 );

--- a/lib/model/hive/goal.dart
+++ b/lib/model/hive/goal.dart
@@ -10,11 +10,14 @@ part "goal.g.dart";
 /// This class is written to hive, so it needs a type adapter.
 @HiveType(typeId: 3)
 class Goal {
-  Goal({ required this.name, required this.reports });
+  Goal({ required this.name, required this.reports, required this.id });
 
   @HiveField(0)
   String name;
 
   @HiveField(1)
   List<Report> reports;
+
+  @HiveField(2)
+  String id;
 }

--- a/lib/model/hive/goal.dart
+++ b/lib/model/hive/goal.dart
@@ -1,0 +1,20 @@
+import "package:hive_flutter/hive_flutter.dart";
+
+import "report.dart";
+
+/// This allows the `Goal` class to access private members in
+/// the generated file. The value for this is *.g.dart, where
+/// the star denotes the source file name.
+part "goal.g.dart";
+
+/// This class is written to hive, so it needs a type adapter.
+@HiveType(typeId: 3)
+class Goal {
+  Goal({ required this.name, required this.reports });
+
+  @HiveField(0)
+  String name;
+
+  @HiveField(1)
+  List<Report> reports;
+}

--- a/lib/model/hive/goal.g.dart
+++ b/lib/model/hive/goal.g.dart
@@ -19,7 +19,7 @@ class GoalAdapter extends TypeAdapter<Goal> {
     return Goal(
       name: fields[0] as String,
       reports: (fields[1] as List).cast<Report>(),
-      id: fields[2] as int,
+      id: fields[2] as String,
     );
   }
 

--- a/lib/model/hive/goal.g.dart
+++ b/lib/model/hive/goal.g.dart
@@ -1,32 +1,35 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'main.dart';
+part of 'goal.dart';
 
 // **************************************************************************
 // TypeAdapterGenerator
 // **************************************************************************
 
-class MainAdapter extends TypeAdapter<Main> {
+class GoalAdapter extends TypeAdapter<Goal> {
   @override
-  final int typeId = 2;
+  final int typeId = 3;
 
   @override
-  Main read(BinaryReader reader) {
+  Goal read(BinaryReader reader) {
     final numOfFields = reader.readByte();
     final fields = <int, dynamic>{
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
-    return Main(
-      goals: (fields[0] as Map).cast<String, Goal>(),
+    return Goal(
+      name: fields[0] as String,
+      reports: (fields[1] as List).cast<Report>(),
     );
   }
 
   @override
-  void write(BinaryWriter writer, Main obj) {
+  void write(BinaryWriter writer, Goal obj) {
     writer
-      ..writeByte(1)
+      ..writeByte(2)
       ..writeByte(0)
-      ..write(obj.goals);
+      ..write(obj.name)
+      ..writeByte(1)
+      ..write(obj.reports);
   }
 
   @override
@@ -35,7 +38,7 @@ class MainAdapter extends TypeAdapter<Main> {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is MainAdapter &&
+      other is GoalAdapter &&
           runtimeType == other.runtimeType &&
           typeId == other.typeId;
 }

--- a/lib/model/hive/goal.g.dart
+++ b/lib/model/hive/goal.g.dart
@@ -19,17 +19,20 @@ class GoalAdapter extends TypeAdapter<Goal> {
     return Goal(
       name: fields[0] as String,
       reports: (fields[1] as List).cast<Report>(),
+      id: fields[2] as int,
     );
   }
 
   @override
   void write(BinaryWriter writer, Goal obj) {
     writer
-      ..writeByte(2)
+      ..writeByte(3)
       ..writeByte(0)
       ..write(obj.name)
       ..writeByte(1)
-      ..write(obj.reports);
+      ..write(obj.reports)
+      ..writeByte(2)
+      ..write(obj.id);
   }
 
   @override

--- a/lib/model/hive/main.dart
+++ b/lib/model/hive/main.dart
@@ -1,6 +1,6 @@
 import "package:hive_flutter/hive_flutter.dart";
 
-import "report.dart";
+import "goal.dart";
 
 /// This allows the `Main` class to access private members in
 /// the generated file. The value for this is *.g.dart, where
@@ -18,5 +18,5 @@ class Main {
   Main({ required this.goals });
 
   @HiveField(0)
-  Map<String, List<Report>> goals;
+  Map<String, Goal> goals;
 }

--- a/lib/widgets/common/goal.dart
+++ b/lib/widgets/common/goal.dart
@@ -19,7 +19,7 @@ class Goal extends StatelessWidget {
       margin: const EdgeInsets.only(bottom: 3),
       child: ElevatedButton(
         onPressed: () {
-          GoRouter.of(context).goNamed("goal", pathParameters: {"goal_name": goalName});
+          GoRouter.of(context).goNamed("goal", pathParameters: {"id": goal.id});
         },
         style: ElevatedButton.styleFrom(
           backgroundColor: Theme.of(context).primaryColor,

--- a/lib/widgets/common/goal.dart
+++ b/lib/widgets/common/goal.dart
@@ -2,14 +2,13 @@
 import "package:flutter/material.dart";
 import "package:go_router/go_router.dart";
 
-import "../../model/hive/report.dart";
+import "../../model/hive/goal.dart"  as model;
 import "goal_name.dart";
 
 class Goal extends StatelessWidget {
-  final String goalName;
-  final List<Report> reports;
+  final model.Goal goal;
 
-  const Goal({super.key, required this.goalName, required this.reports});
+  const Goal({super.key, required this.goal});
 
   @override
   Widget build(BuildContext context) {
@@ -29,7 +28,7 @@ class Goal extends StatelessWidget {
             borderRadius: BorderRadius.all(Radius.circular(2)),
           ),
         ),
-        child: GoalName(completion: reports.length, goalName: goalName,)
+        child: GoalName(completion: goal.reports.length, goalName: goal.name,)
       )
     );
     // return Container(

--- a/lib/widgets/insights/heatmap.dart
+++ b/lib/widgets/insights/heatmap.dart
@@ -10,9 +10,9 @@ DateFormat format = DateFormat("E, d LLL y");
 
 /// Widget to display a calendar heatmap of a specific goal.
 class GoalsHeatMap extends StatelessWidget {
-  final String goalName;
+  final String id;
 
-  const GoalsHeatMap({super.key, required this.goalName});
+  const GoalsHeatMap({super.key, required this.id});
 
   @override
   Widget build(BuildContext context) {
@@ -23,7 +23,7 @@ class GoalsHeatMap extends StatelessWidget {
         if (box.isEmpty) {
           return const SizedBox();
         }
-        final selectedGoal = box.get(mainKey)?.goals[goalName];
+        final selectedGoal = box.get(mainKey)?.goals[id];
         if (selectedGoal == null) {
           throw "Selected goal does not exist";
         }

--- a/lib/widgets/insights/heatmap.dart
+++ b/lib/widgets/insights/heatmap.dart
@@ -28,7 +28,7 @@ class GoalsHeatMap extends StatelessWidget {
           throw "Selected goal does not exist";
         }
         final datasets = <DateTime, int>{};
-        for (var report in selectedGoal) {
+        for (var report in selectedGoal.reports) {
           datasets[format.parse(report.date)] = report.isCompleted ? 1 : 0;
         }
         return HeatMap(

--- a/lib/widgets/insights/heatmap_calendar.dart
+++ b/lib/widgets/insights/heatmap_calendar.dart
@@ -10,9 +10,9 @@ DateFormat format = DateFormat("E, d LLL y");
 
 /// Widget to display a calendar heatmap of a specific goal.
 class GoalsHeatMapCalendar extends StatelessWidget {
-  final String goalName;
+  final String id;
 
-  const GoalsHeatMapCalendar({super.key, required this.goalName});
+  const GoalsHeatMapCalendar({super.key, required this.id});
 
   @override
   Widget build(BuildContext context) {
@@ -23,7 +23,7 @@ class GoalsHeatMapCalendar extends StatelessWidget {
         if (box.isEmpty) {
           return const SizedBox();
         }
-        final selectedGoal = box.get(mainKey)?.goals[goalName];
+        final selectedGoal = box.get(mainKey)?.goals[id];
         if (selectedGoal == null) {
           throw "Selected goal does not exist";
         }

--- a/lib/widgets/insights/heatmap_calendar.dart
+++ b/lib/widgets/insights/heatmap_calendar.dart
@@ -28,7 +28,7 @@ class GoalsHeatMapCalendar extends StatelessWidget {
           throw "Selected goal does not exist";
         }
         final datasets = <DateTime, int>{};
-        for (var report in selectedGoal) {
+        for (var report in selectedGoal.reports) {
           datasets[format.parse(report.date)] = report.isCompleted ? 1 : 0;
         }
         final max = datasets.keys.reduce((a,b) => a.isAfter(b) ? a : b);

--- a/lib/widgets/pages/goal.dart
+++ b/lib/widgets/pages/goal.dart
@@ -6,9 +6,9 @@ import "../insights/heatmap.dart";
 import "../insights/heatmap_calendar.dart";
 
 class GoalPage extends StatelessWidget {
-  final String? goalName;
+  final String? id;
 
-  const GoalPage({super.key, required this.goalName});
+  const GoalPage({super.key, required this.id});
 
   @override
   Widget build(BuildContext context) {
@@ -16,13 +16,13 @@ class GoalPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text("Zebra"),
       ),
-      body: goalName != null ? Column(
+      body: id != null ? Column(
         children: [
           card_widget.Card(
-            child: GoalsHeatMapCalendar(goalName: goalName!,)
+            child: GoalsHeatMapCalendar(id: id!,)
           ),
           card_widget.Card(
-            child: GoalsHeatMap(goalName: goalName!,)
+            child: GoalsHeatMap(id: id!,)
           ),
         ]
       ) : const Text("No goal found."),

--- a/lib/widgets/pages/goals.dart
+++ b/lib/widgets/pages/goals.dart
@@ -27,7 +27,7 @@ class GoalsPage extends StatelessWidget {
         return ListView.builder(
           itemCount: goalNames.length,
           itemBuilder: (BuildContext context, int index) {
-            return Goal(goalName: goalNames[index], reports: goals[goalNames[index]]?.reports ?? List.empty());
+            return Goal(goal: goals[goalNames[index]]!);
           }
         );
       }

--- a/lib/widgets/pages/goals.dart
+++ b/lib/widgets/pages/goals.dart
@@ -22,12 +22,12 @@ class GoalsPage extends StatelessWidget {
         goalNames.sort((a, b) {
           final aGoal = goals[a]!;
           final bGoal = goals[b]!;
-          return bGoal.length - aGoal.length;
+          return bGoal.reports.length - aGoal.reports.length;
         });
         return ListView.builder(
           itemCount: goalNames.length,
           itemBuilder: (BuildContext context, int index) {
-            return Goal(goalName: goalNames[index], reports: goals[goalNames[index]] ?? List.empty());
+            return Goal(goalName: goalNames[index], reports: goals[goalNames[index]]?.reports ?? List.empty());
           }
         );
       }

--- a/lib/widgets/upload_button.dart
+++ b/lib/widgets/upload_button.dart
@@ -6,6 +6,7 @@ import "package:hive_flutter/hive_flutter.dart";
 
 import "../common/constants.dart";
 import "../common/util.dart";
+import "../model/hive/goal.dart";
 import "../model/hive/main.dart";
 import "../model/hive/report.dart";
 
@@ -19,17 +20,17 @@ class UploadButton extends StatelessWidget {
     try {
       FilePickerResult? result = await FilePicker.platform.pickFiles(type: FileType.custom, allowedExtensions: ["zip"], withData: true );
       final goals = await getAndParseFinchExport(result);
-      final reports = <String, List<Report>>{};
+      final reports = <String, Goal>{};
       for (var key in goals.keys) {
         final goal = goals[key];
         if (goal == null) {
           continue;
         }
         if (reports[key] == null) {
-          reports[key] = [];
+          reports[key] = Goal(name: key, reports: []);
         }
         for (var g in goal) {
-          reports[key]?.add(Report(date: g.date, isCompleted: g.completedTime != ""));
+          reports[key]?.reports.add(Report(date: g.date, isCompleted: g.completedTime != ""));
         }
       }
       await box.delete(mainKey);

--- a/lib/widgets/upload_button.dart
+++ b/lib/widgets/upload_button.dart
@@ -3,6 +3,7 @@ import "package:file_picker/file_picker.dart";
 import "package:flutter/material.dart";
 import "package:fluttertoast/fluttertoast.dart";
 import "package:hive_flutter/hive_flutter.dart";
+import "package:uuid/uuid.dart";
 
 import "../common/constants.dart";
 import "../common/util.dart";
@@ -21,13 +22,14 @@ class UploadButton extends StatelessWidget {
       FilePickerResult? result = await FilePicker.platform.pickFiles(type: FileType.custom, allowedExtensions: ["zip"], withData: true );
       final goals = await getAndParseFinchExport(result);
       final reports = <String, Goal>{};
+      var uuid = const Uuid();
       for (var key in goals.keys) {
         final goal = goals[key];
         if (goal == null) {
           continue;
         }
         if (reports[key] == null) {
-          reports[key] = Goal(name: key, reports: []);
+          reports[key] = Goal(id: uuid.v4(), name: key, reports: []);
         }
         for (var g in goal) {
           reports[key]?.reports.add(Report(date: g.date, isCompleted: g.completedTime != ""));

--- a/lib/widgets/upload_button.dart
+++ b/lib/widgets/upload_button.dart
@@ -25,14 +25,15 @@ class UploadButton extends StatelessWidget {
       var uuid = const Uuid();
       for (var key in goals.keys) {
         final goal = goals[key];
+        final id = uuid.v4();
         if (goal == null) {
           continue;
         }
-        if (reports[key] == null) {
-          reports[key] = Goal(id: uuid.v4(), name: key, reports: []);
+        if (reports[id] == null) {
+          reports[id] = Goal(id: id, name: key, reports: []);
         }
         for (var g in goal) {
-          reports[key]?.reports.add(Report(date: g.date, isCompleted: g.completedTime != ""));
+          reports[id]?.reports.add(Report(date: g.date, isCompleted: g.completedTime != ""));
         }
       }
       await box.delete(mainKey);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -653,6 +653,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   stack_trace:
     dependency: transitive
     description:
@@ -789,6 +797,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.0"
+  uuid:
+    dependency: "direct main"
+    description:
+      name: uuid
+      sha256: f33d6bb662f0e4f79dcd7ada2e6170f3b3a2530c28fc41f49a411ddedd576a77
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.0"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   go_router: ^14.2.7
   url_launcher: ^6.3.0
   url_strategy: ^0.3.0
+  uuid: ^4.5.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Overview

Add a dedicated `Goal` class to be saved in hive. The purpose of the PR is to add a unique generated ID for each goal. 

The Finch json export does not have a unique ID for each goal, the name is used as an identifier for now, which is error prone for identifying a single goal.

### Changes in this PR

- Add `Goal` hive type adapter.
- Refactor code to use this new type adapter.
- Add a unique ID for each goal when importing the goal using `uuid` package.
- Use this ID to generate URLs.