### PR TITLE
Add journey page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import "model/hive/main.dart";
 import "model/hive/report.dart";
 import "widgets/home.dart";
 import "widgets/pages/goal.dart";
+import "widgets/pages/journey.dart";
 
 // GoRouter configuration
 final _router = GoRouter(
@@ -18,6 +19,11 @@ final _router = GoRouter(
       path: "/",
       name: "home",
       builder: (context, state) => const ZebraHomePage(),
+    ),
+    GoRoute(
+      name: "journey",
+      path: "/journey",
+      builder: (context, state) => const JourneyPage(),
     ),
     GoRoute(
       name: "goal",

--- a/lib/widgets/pages/journey.dart
+++ b/lib/widgets/pages/journey.dart
@@ -1,0 +1,47 @@
+
+import "package:flutter/material.dart";
+import "package:multi_select_flutter/multi_select_flutter.dart";
+
+import "../../common/constants.dart";
+
+class JourneyPage extends StatelessWidget {
+  const JourneyPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder(
+      valueListenable: getZebraBox(),
+      builder: (context, box, widget) {
+        final goals = box.get(mainKey)?.goals;
+        if (goals == null || goals.isEmpty) {
+          // Render empty box when list of goals is empty.
+          return const SizedBox();
+        }
+        final List<String> goalNames = List.from(goals.keys);
+        // Sort keys by number of reports.
+        goalNames.sort((a, b) {
+          final aGoal = goals[a]!;
+          final bGoal = goals[b]!;
+          return bGoal.reports.length - aGoal.reports.length;
+        });
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text("Journey"),
+          ),
+          body: Column(
+            children: [
+              MultiSelectDialogField(
+                items: goalNames.map((e) => MultiSelectItem(e, goals[e]?.name ?? "Unknown goal")).toList(),
+                listType: MultiSelectListType.CHIP,
+                onConfirm: (values) {
+                  // _selectedAnimals = values;
+                },
+              ),
+            ]
+          ),
+        );
+      }
+    );
+  }
+}
+

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -488,6 +488,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  multi_select_flutter:
+    dependency: "direct main"
+    description:
+      name: multi_select_flutter
+      sha256: "503857b415d390d29159df8a9d92d83c6aac17aaf1c307fb7bcfc77d097d20ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.3"
   nested:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   url_launcher: ^6.3.0
   url_strategy: ^0.3.0
   uuid: ^4.5.0
+  multi_select_flutter: ^4.1.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Overview

Journeys at the time cannot be identified based on the export data. An alternative is to let the user select multiple goals using a multi-select, then display the journey that way.

This is experimental, so it is hidden in a different route than the rest of the application.

### Changes in this PR

- Add new route `journey`
- Add new widget `JourneyPage`
- Add dependency on `multi_select_flutter` to display goals.